### PR TITLE
feat: update cropperjs to v.1.5.10 and slight refactor

### DIFF
--- a/example/src/Demo.tsx
+++ b/example/src/Demo.tsx
@@ -1,13 +1,13 @@
 import React, {useState, useRef} from 'react';
 import 'cropperjs/dist/cropper.css';
-import {Cropper} from '../../src';
+import {Cropper, ReactCropperElement} from '../../src';
 
 const defaultSrc = 'example/img/child.jpg';
 
 export const Demo: React.FC = () => {
     const [image, setImage] = useState(defaultSrc);
     const [cropData, setCropData] = useState('#');
-    const imageRef = useRef<HTMLImageElement>(null);
+    const imageRef = useRef<ReactCropperElement>(null);
     const [cropper, setCropper] = useState<Cropper>();
     const onChange = (e: any) => {
         e.preventDefault();

--- a/package-lock.json
+++ b/package-lock.json
@@ -7413,9 +7413,9 @@
       }
     },
     "cropperjs": {
-      "version": "1.5.9",
-      "resolved": "https://registry.npmjs.org/cropperjs/-/cropperjs-1.5.9.tgz",
-      "integrity": "sha512-aPWlg43sLIcYN4GBXIdyvM09wNPgn1ug+vNVwV8jlb3dbgEX/B34Iw6hrjGSajkUDQBmaCi6uPOevFb7N0yUsw=="
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/cropperjs/-/cropperjs-1.5.10.tgz",
+      "integrity": "sha512-Zlggv+unsBXVc7EQip6rnOqFnFpHOIc4f8HqzAj3RQNEUNjrCCJyE7OlT/V8S0lO2m4ytRoceTlgzEh1DNMU0Q=="
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "url": "https://github.com/react-cropper/react-cropper.git"
   },
   "dependencies": {
-    "cropperjs": "^1.5.9"
+    "cropperjs": "^1.5.10"
   },
   "peerDependencies": {
     "react": ">=16.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export {ReactCropper as Cropper} from './react-cropper';
 export {ReactCropper as default} from './react-cropper';
-export {ReactCropperProps} from './react-cropper';
+export type {ReactCropperProps, ReactCropperElement} from './react-cropper';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,18 +1,27 @@
 import React from 'react';
 import Cropper from 'cropperjs';
-interface ReactCropperProps
-    extends Cropper.Options,
-        Omit<React.HTMLProps<HTMLImageElement>, 'data' | 'ref' | 'crossOrigin'> {
-    crossOrigin?: '' | 'anonymous' | 'use-credentials' | undefined;
-    on?: (eventName: string, callback: () => void | Promise<void>) => void | Promise<void>;
+interface ReactCropperElement extends HTMLImageElement {
+    cropper: Cropper;
+}
+interface ReactCropperDefaultOptions {
     scaleX?: number;
     scaleY?: number;
     enable?: boolean;
     zoomTo?: number;
     rotateTo?: number;
+}
+interface ReactCropperProps
+    extends ReactCropperDefaultOptions,
+        Cropper.Options<HTMLImageElement>,
+        Omit<React.HTMLProps<HTMLImageElement>, 'data' | 'ref' | 'crossOrigin'> {
+    crossOrigin?: '' | 'anonymous' | 'use-credentials' | undefined;
+    on?: (eventName: string, callback: () => void | Promise<void>) => void | Promise<void>;
     onInitialized?: (instance: Cropper) => void | Promise<void>;
 }
-declare const ReactCropper: React.ForwardRefExoticComponent<ReactCropperProps & React.RefAttributes<HTMLImageElement>>;
+declare const applyDefaultOptions: (cropper: Cropper, options?: ReactCropperDefaultOptions) => void;
+declare const ReactCropper: React.ForwardRefExoticComponent<
+    ReactCropperProps & React.RefAttributes<HTMLImageElement | ReactCropperElement>
+>;
 export {ReactCropper as Cropper};
 export {ReactCropper as default};
 export {ReactCropperProps};

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -24,4 +24,4 @@ declare const ReactCropper: React.ForwardRefExoticComponent<
 >;
 export {ReactCropper as Cropper};
 export {ReactCropper as default};
-export {ReactCropperProps};
+export {ReactCropperProps, ReactCropperElement};


### PR DESCRIPTION
This PR handles the following:
- Removes internal state where cropper was set and use `ref` to get cropper (for less re-render)
- Introduces `ReactCropperElement` which extends `HTMLImageElement` to add missing `cropper` field
- Upgrades cropperjs to v1.5.10