### PR TITLE
Fix usage with Preact

### DIFF
--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -2,7 +2,7 @@
   "include": ["src", "example"],
   "compilerOptions": {
     "lib": ["es6", "dom"],
-    "jsx": "react-jsx",
+    "jsx": "react",
     "allowJs": true,
     "sourceMap": true,
     "importHelpers": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "include": ["src"],
   "compilerOptions": {
     "lib": ["es6", "dom"],
-    "jsx": "react-jsx",
+    "jsx": "react",
     "allowJs": true,
     "declaration": true,
     "sourceMap": false,


### PR DESCRIPTION
**Issue**
I'm using react-cropper with Preact and Webpack but I'm running into this error when rendering the component:

> Cannot read properties of undefined (reading 'current')

**Reproduction**
https://codesandbox.io/s/confident-tharp-8gkryk?file=/src/demo.js

**Solution**
Change jsx runtime to classic which will fix compatibility with Preact.

**More Info**
- https://www.typescriptlang.org/tsconfig#jsx
- https://github.com/DominicTobias/react-image-crop/pull/500